### PR TITLE
use new URL() instead of URL.parse() to solve ios compatibility issues

### DIFF
--- a/sdk/src/backend/getReceipt.ts
+++ b/sdk/src/backend/getReceipt.ts
@@ -1,5 +1,5 @@
 import { backendUrl } from "../config";
-import { ReceiptSignatures, ReceiptWithMeta } from "../types/receipt";
+import { ReceiptSignatures, ReceiptWithMeta } from "../types";
 
 /**
  * Parse a receipt with meta returned from the backend into a ReceiptWithMeta.
@@ -53,7 +53,7 @@ export function parseReceiptWithMeta(receiptWithMeta: {
  * @throws Will throw an error if the network request fails or the receipt is not found.
  */
 export async function getReceiptIdByTxHash(txHash: string): Promise<string> {
-  const receiptIdByTxHashUrl: URL = URL.parse(
+  const receiptIdByTxHashUrl: URL = new URL(
     `/api/receipts/transaction/${txHash}`,
     backendUrl,
   )!;
@@ -82,7 +82,7 @@ export async function getAllReceipts(
   offset: number = 0,
   ordering: "asc" | "desc" = "desc",
 ): Promise<Array<ReceiptWithMeta>> {
-  const receiptsUrl: URL = URL.parse("/api/receipts", backendUrl)!;
+  const receiptsUrl: URL = new URL("/api/receipts", backendUrl)!;
   receiptsUrl.searchParams.set("limit", limit.toString());
   receiptsUrl.searchParams.set("offset", offset.toString());
   receiptsUrl.searchParams.set("ordering", ordering);
@@ -115,7 +115,7 @@ export async function getReceiptsByAddress(
   offset: number = 0,
   ordering: "asc" | "desc" = "desc",
 ): Promise<Array<ReceiptWithMeta>> {
-  const receiptsByAddressUrl: URL = URL.parse(
+  const receiptsByAddressUrl: URL = new URL(
     `/api/receipts/user/${address}`,
     backendUrl,
   )!;
@@ -143,7 +143,7 @@ export async function getReceiptsByAddress(
  */
 
 export async function getReceipt(receiptId: string): Promise<ReceiptWithMeta> {
-  const receiptByIdUrl: URL = URL.parse(
+  const receiptByIdUrl: URL = new URL(
     `/api/receipts/${receiptId}`,
     backendUrl,
   )!;
@@ -169,7 +169,7 @@ export async function getReceipt(receiptId: string): Promise<ReceiptWithMeta> {
 export async function getReceiptSignature(
   receiptId: string,
 ): Promise<ReceiptSignatures> {
-  const receiptByIdUrl: URL = URL.parse(
+  const receiptByIdUrl: URL = new URL(
     `/api/receipts/signatures/${receiptId}`,
     backendUrl,
   )!;

--- a/sdk/src/backend/getSendPayload.ts
+++ b/sdk/src/backend/getSendPayload.ts
@@ -1,6 +1,6 @@
 import { Hex } from "viem";
 import { backendUrl } from "../config";
-import { SendPayloadResponse } from "../types/payload";
+import { SendPayloadResponse } from "../types";
 import { addressToBytes32 } from "../evm/bridge/helpers";
 
 /**
@@ -28,7 +28,7 @@ export async function getSendPayload(
   flags: bigint = 0n,
   flagData: Hex = "0x",
 ): Promise<SendPayloadResponse> {
-  const sendPayloadUrl: URL = URL.parse("/api/send", backendUrl)!;
+  const sendPayloadUrl: URL = new URL("/api/send", backendUrl)!;
   sendPayloadUrl.searchParams.set("networkFrom", networkFrom.toString());
   sendPayloadUrl.searchParams.set("networkTo", networkTo.toString());
   if (tokenAddress.length !== 66 && tokenAddress.startsWith("0x")) {

--- a/sdk/src/backend/getTokensConfig.ts
+++ b/sdk/src/backend/getTokensConfig.ts
@@ -1,5 +1,5 @@
 import { backendUrl } from "../config";
-import { TokenConfig } from "../types/tokenConfig";
+import { TokenConfig } from "../types";
 
 /**
  * Fetches the tokens configuration from the backend API.
@@ -10,7 +10,7 @@ import { TokenConfig } from "../types/tokenConfig";
  */
 
 export async function getTokensConfig(): Promise<TokenConfig> {
-  const tokensConfigUrl: URL = URL.parse("/api/tokens", backendUrl)!;
+  const tokensConfigUrl: URL = new URL("/api/tokens", backendUrl)!;
   const response = await fetch(tokensConfigUrl);
   if (!response.ok) {
     throw new Error(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved URL construction across several backend features for increased reliability and consistency.
  * Updated import paths for type definitions to streamline code organization.

No changes to user-facing functionality or exported interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->